### PR TITLE
chore: 重命名项目为 algo-grind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_OSX_SYSROOT /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk)
 set(CMAKE_C_COMPILER "/opt/homebrew/opt/llvm/bin/clang")
 set(CMAKE_CXX_COMPILER "/opt/homebrew/opt/llvm/bin/clang++")
 
-project(_algorithm C CXX)
+project(algo-grind C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD 17)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ⚡ _algorithm
+# ⚡ algo-grind
 
 > **One problem, multiple languages. Zero excuses.**
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module _algorithm
+module algo-grind
 
 go 1.26.4

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>top.chenbxxx</groupId>
-    <artifactId>_algorithm</artifactId>
+    <artifactId>algo-grind</artifactId>
     <version>1.0-SNAPSHOT</version>
     <build>
         <sourceDirectory>src/java</sourceDirectory>


### PR DESCRIPTION
## Summary
- 更新 CMakeLists.txt、go.mod、pom.xml、README 中的项目名称 `_algorithm` → `algo-grind`

🤖 Generated with [Claude Code](https://claude.com/claude-code)